### PR TITLE
Fix display name

### DIFF
--- a/modules/authcore/lib/Core/AuthSession/AuthUser.php
+++ b/modules/authcore/lib/Core/AuthSession/AuthUser.php
@@ -85,7 +85,7 @@ class AuthUser
     {
         if ($this->account) {
             $displayName = $this->account->getRealName();
-            if ($displayName) {
+            if (trim($displayName)) {
                 return $displayName;
             }
         }


### PR DESCRIPTION
`Account::getDisplayName()` method can return a simple space string if last name and first name are empty

see https://github.com/jelix/authentication-module/blob/871b339600cd7160f2967d52f83370f653a13705/modules/account/lib/Account.php#L48

use trim to check if the displayName value is relevant