### PR TITLE
Fix password recovery

### DIFF
--- a/modules/authloginpass/lib/PasswordReset.php
+++ b/modules/authloginpass/lib/PasswordReset.php
@@ -213,7 +213,7 @@ class PasswordReset {
         if ($backend) {
             $userRequest->saveAsConfirmed();
 
-            $this->manager->changePassword($login, $newPassword, $backend->getLabel());
+            $this->manager->changePassword($login, $newPassword, $backend->getRegisterKey());
         }
     }
 


### PR DESCRIPTION
When reseting a password the new one is not updated on the database 

the manager use the backendLabel to indicate the bakend storing the user
https://github.com/jelix/authentication-module/blob/871b339600cd7160f2967d52f83370f653a13705/modules/authloginpass/lib/PasswordReset.php#L216
but the manager search by name
https://github.com/jelix/authentication-module/blob/871b339600cd7160f2967d52f83370f653a13705/modules/authloginpass/lib/Manager.php#L179

and `$backend is null` 
in 
https://github.com/jelix/authentication-module/blob/871b339600cd7160f2967d52f83370f653a13705/modules/authloginpass/lib/Manager.php#L184

and the password isn't updated