### PR TITLE
Notify use when authentication is performed

### DIFF
--- a/docs/en/authcore.md
+++ b/docs/en/authcore.md
@@ -26,6 +26,8 @@ signOutAction="authcore~sign:out"
 ; action to redirect to when displaying the login page whereas the user is
 ; already authenticated. Typical action: the action of the home page
 signInAlreadyAuthAction=
+; always/never/enabled/disabled (enabled/disabled : user can override value)
+notifyAuthMode=
 
 [sessionauth]
 ; action to redirect to when authentication is needed and the user is not authenticated

--- a/modules/account/classes/authAccount.listener.php
+++ b/modules/account/classes/authAccount.listener.php
@@ -1,6 +1,7 @@
 <?php
 
 use Jelix\Authentication\Account;
+use Jelix\Authentication\Account\Notification\AuthenticationNotifier;
 use Jelix\Authentication\Core\Workflow\Event\GetAccountEvent;
 use Jelix\Authentication\Core\Workflow\Step\StepException;
 use Jelix\Authentication\LoginPass\AuthLPCanResetPasswordEvent;
@@ -27,6 +28,8 @@ class authAccountListener extends jEventListener
         $account = Account\Manager::searchAccountByIdp($idpId, $user->getUserId(), true);
         if ($account) {
             $event->setAccount($account);
+            $notifier = new AuthenticationNotifier();
+            $notifier->successAuth($account);
         }
         else {
             $isAccountCreationAllowed = false;

--- a/modules/account/controllers/profile.classic.php
+++ b/modules/account/controllers/profile.classic.php
@@ -6,6 +6,7 @@
 
 use Jelix\Authentication\Account\Manager;
 use Jelix\Authentication\Account\Account;
+use Jelix\Authentication\Account\Notification\AuthenticationNotifier;
 
 class profileCtrl extends jController {
 
@@ -27,6 +28,7 @@ class profileCtrl extends jController {
         }
 
         $form->initFromDao('account~accounts', $formId);
+        $this->disableNotificationCtrlIfDenied($form);
 
         $tpl = new \jTpl();
         $tpl->assign('form', $form);
@@ -54,6 +56,7 @@ class profileCtrl extends jController {
         }
 
         $form->initFromDao('account~accounts', $formId);
+        $this->disableNotificationCtrlIfDenied($form);
 
         $tpl = new jTpl();
         $tpl->assign('form', $form);
@@ -106,6 +109,14 @@ class profileCtrl extends jController {
         $rep->action = 'account~profile:index';
 
         return $rep;
+    }
+
+    protected function disableNotificationCtrlIfDenied(jFormsBase $form) {
+        $notifier = new AuthenticationNotifier();
+
+        if (!$notifier->canUsersOverwriteNotifConf()) {
+            $form->getControl('notify_auth_success')->deactivate();
+        }
     }
 }
 

--- a/modules/account/daos/accounts.dao.xml
+++ b/modules/account/daos/accounts.dao.xml
@@ -25,6 +25,7 @@
            0 new account, invalid account
            1 valid account
            -->
+      <property name="notify_auth_success" fieldname="notify_auth_success" datatype="integer" />
       <property name="create_date" fieldname="create_date" datatype="datetime"
                 insertpattern="now()" updatepattern=""/>
 

--- a/modules/account/forms/profile_modify.form.xml
+++ b/modules/account/forms/profile_modify.form.xml
@@ -16,6 +16,11 @@
     <input type="email" ref="email">
         <label locale="account~account.profile.th.email"/>
     </input>
+    <radiobuttons ref="notify_auth_success" required='true'>
+        <label locale="account~account.profile.th.notify_auth_success"/>
+        <item value="1" locale='account~account.profile.notify_auth_success.text.on' />
+        <item value="0" locale='account~account.profile.notify_auth_success.text.off' />
+    </radiobuttons >
 
 <output ref="create_date">
     <label locale="account~account.profile.th.createdate"/>

--- a/modules/account/install/sql/add_notify_auth_success.sql
+++ b/modules/account/install/sql/add_notify_auth_success.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounts ADD COLUMN notify_auth_success integer;

--- a/modules/account/install/upgrade_041.php
+++ b/modules/account/install/upgrade_041.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @author    Laurent Jouanneau
+ * @copyright 2024 Laurent Jouanneau
+ *
+ * @see       https://jelix.org
+ * @licence   MIT
+ */
+
+class accountModuleUpgrader_041 extends \Jelix\Installer\Module\Installer
+{
+    protected $targetVersions = array('0.4.1');
+    protected $date = '2025-08-22';
+
+    public function install(Jelix\Installer\Module\API\InstallHelpers $helpers)
+    {
+        $helpers->database()->execSQLScript('sql/add_notify_auth_success.sql');
+    }
+}

--- a/modules/account/lib/Account.php
+++ b/modules/account/lib/Account.php
@@ -57,4 +57,9 @@ class Account implements UserAccountInterface
     {
         return $this->data['email'];
     }
+
+    public function getNotifyAuthSuccess()
+    {
+        return $this->data['notify_auth_success'];
+    }
 }

--- a/modules/account/lib/Notification/AuthenticationNotifier.php
+++ b/modules/account/lib/Notification/AuthenticationNotifier.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Jelix\Authentication\Account\Notification;
+
+use DateTimeImmutable;
+use DomainException;
+use Jelix\Authentication\Account\Account;
+use Jelix\Core\Infos\AppInfos;
+
+class AuthenticationNotifier
+{
+    public const NOTIFY_NEVER = 'never';
+    public const NOTIFY_ALWAYS = 'always';
+    public const NOTIFY_ON_USER_CAN_OPT_OUT = 'enabled';
+    public const NOTIFY_OFF_USER_CAN_OPT_IN = 'disabled';
+
+    private $notifyMode;
+    public function __construct()
+    {
+        $config = \jApp::config()->authentication;
+        if (isset($config['notifyAuthMode']) && $config['notifyAuthMode']) {
+            $this->notifyMode = $config['notifyAuthMode'];
+            if(!in_array($this->notifyMode, [self::NOTIFY_ALWAYS, self::NOTIFY_NEVER, self::NOTIFY_OFF_USER_CAN_OPT_IN, self::NOTIFY_ON_USER_CAN_OPT_OUT])) {
+                throw new DomainException('not a valid notifyAuthMode value');
+            }
+        } else {
+            // use never
+            $this->notifyMode = self::NOTIFY_NEVER;
+            trigger_error('no value defined for notifyAuthMode, using "never"', E_USER_NOTICE);
+        }
+    }
+
+    private function isNotificationEnabled(Account $account)
+    {
+        if ($this->notifyMode == self::NOTIFY_ALWAYS || $this->notifyMode == self::NOTIFY_ALWAYS) {
+            return $this->notifyMode == self::NOTIFY_ALWAYS;
+        }
+        // must check Account value
+        $value = $account->getNotifyAuthSuccess();
+        if($this->notifyMode == self::NOTIFY_OFF_USER_CAN_OPT_IN) {
+            return $value == 1 ;
+        }
+        if($this->notifyMode == self::NOTIFY_ON_USER_CAN_OPT_OUT) {
+            return $value != 0 ;
+        }
+    }
+
+    public function successAuth(Account $account)
+    {
+        // notify
+        if($this->isNotificationEnabled($account)) {
+            $appInfos  = AppInfos::load();
+            $appName = $appInfos->getLabel();
+            $email = $account->getEmail();
+            $mailer = new \jMailer();
+            $mailer->addAddress($email);
+            $mailer->Subject = \jLocale::get('account~account.email.auth.success.subject', [$email, $appName]);
+            $tpl = $mailer->Tpl('account~mailBodyAuthSuccess', true);
+            $tpl->assign('email', $email);
+            $tpl->assign('appName', $appName);
+            $tpl->assign('authDateTime', (new DateTimeImmutable())->format('Y-m-d H:i:s'));
+            $mailer->send();
+        }
+    }
+
+    public function canUsersOverwriteNotifConf(): bool
+    {
+        return in_array($this->notifyMode, [self::NOTIFY_OFF_USER_CAN_OPT_IN, self::NOTIFY_ON_USER_CAN_OPT_OUT]);
+    }
+}

--- a/modules/account/locales/en_US/account.UTF-8.properties
+++ b/modules/account/locales/en_US/account.UTF-8.properties
@@ -24,3 +24,5 @@ cancel.and.back.to.profile = Cancel and back to your profile
 back.to.profile = Back to your profile
 
 error.no.account=Sorry, there is no account with the login %s into this application.
+
+email.auth.success.subject=New login with e-mail %s on app %s

--- a/modules/account/locales/en_US/account.UTF-8.properties
+++ b/modules/account/locales/en_US/account.UTF-8.properties
@@ -9,6 +9,9 @@ profile.th.email = Email
 profile.th.status = Status
 profile.th.createdate = Account's creation date
 profile.th.provider = Authentication provider
+profile.th.notify_auth_success = Receive an email notification each time you log in
+profile.notify_auth_success.text.on= On
+profile.notify_auth_success.text.off= Off
 
 profile.button.modify = Modify
 

--- a/modules/account/locales/fr_FR/account.UTF-8.properties
+++ b/modules/account/locales/fr_FR/account.UTF-8.properties
@@ -24,3 +24,5 @@ cancel.and.back.to.profile = Annuler et retourner à votre profil
 back.to.profile = Retourner à votre profil
 
 error.no.account=Désolé, il n'y a pas de compte avec l'identifiant %s dans cette application.
+
+email.auth.success.subject=Nouvelle connexion du compte %s sur l'application %s

--- a/modules/account/locales/fr_FR/account.UTF-8.properties
+++ b/modules/account/locales/fr_FR/account.UTF-8.properties
@@ -9,6 +9,9 @@ profile.th.email = Email
 profile.th.status = Statut
 profile.th.createdate = Date de création du compte
 profile.th.provider = Service d'authentification
+profile.th.notify_auth_success = Recevoir une notification e-mail à chaque connexion
+profile.notify_auth_success.text.on= Actif
+profile.notify_auth_success.text.off= Inactif
 
 profile.button.modify = Modifier
 

--- a/modules/account/module.xml
+++ b/modules/account/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module xmlns="http://jelix.org/ns/module/1.0">
     <info id="account@jelix.org" name="account" createdate="2021-01-12">
-        <version date="2025-06-16">0.4.0</version>
+        <version date="2025-08-22">0.4.1</version>
         <label lang="en_US">account</label>
         <description lang="en_US" />
         <license URL="">All rights reserved</license>

--- a/modules/account/templates/en_US/mailBodyAuthSuccess.tpl
+++ b/modules/account/templates/en_US/mailBodyAuthSuccess.tpl
@@ -1,0 +1,8 @@
+<p>Hello</p>
+<p>
+A new login has just been made on the {$appName} application with your email address {$email}
+</p><p>
+Date and time: {$authDateTime}
+</p><p>
+If this login corresponds to your activity, you can ignore this message.
+</p>

--- a/modules/account/templates/fr_FR/mailBodyAuthSuccess.tpl
+++ b/modules/account/templates/fr_FR/mailBodyAuthSuccess.tpl
@@ -1,0 +1,8 @@
+<p>Bonjour</p>
+<p>
+Une nouvelle connexion vient d'être réalisée sur l'application {$appName} avec votre adresse e-mail {$email}
+</p><p>
+Date et heure : {$authDateTime}
+</p><p>
+Si cette connexion correspond à votre activité, vous pouvez ignorer ce message.
+</p>

--- a/test/testapp/app/system/mainconfig.ini.php
+++ b/test/testapp/app/system/mainconfig.ini.php
@@ -197,6 +197,7 @@ idp[]=alwaysyes
 sessionHandler=php
 
 signInAlreadyAuthAction="adminui~default:index"
+notifyAuthMode=enabled
 
 [sessionauth]
 authRequired=off


### PR DESCRIPTION
add `notifyAuthMode` config (values `always/never/enabled/disabled`) to perform a user notification when user log in 

update profile controller (and form/dao/templte) to allow user to set his notifications preferences (if allowed) 

Refs #21 